### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/scripts/bot/fix-ephemeral.js
+++ b/scripts/bot/fix-ephemeral.js
@@ -29,7 +29,10 @@ function processFile (filePath) {
         const importMatch = content.match(/import\s+{[^}]*}\s+from\s+['"]discord\.js['"]/);
         if (importMatch) {
           // Ajouter MessageFlags à l'import existant
-          content = content.replace(importMatch[0], importMatch[0].replace('}', ', MessageFlags }'));
+          content = content.replace(
+            /import\s+{([^}]*)}\s+from\s+(['"]discord\.js['"])/,
+            (match, imports, source) => `import {${imports.trim()}, MessageFlags } from ${source}`
+          );
         } else {
           // Ajouter un nouvel import
           content = `import { MessageFlags } from 'discord.js';\n${content}`;


### PR DESCRIPTION
Potential fix for [https://github.com/n3m01726/discord-bot/security/code-scanning/3](https://github.com/n3m01726/discord-bot/security/code-scanning/3)

Use a regex replacement that targets the named import block and appends `MessageFlags` inside it, instead of replacing the first `}` character.

Best fix in this file:
- In `scripts/bot/fix-ephemeral.js`, replace line 32 logic with a capture-group based regex replacement:
  - Match `import { ... } from 'discord.js'`
  - Capture the inside of braces
  - Rebuild the import as `import { <existing>, MessageFlags } from 'discord.js'`
- This avoids first-occurrence string replacement and makes the transformation explicit and stable.
- No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
