### PR TITLE
refactor: clean interaction handlers and remove magic ephemeral flags

### DIFF
--- a/src/bot/handlers/ButtonHandler.js
+++ b/src/bot/handlers/ButtonHandler.js
@@ -2,6 +2,7 @@
 // bot/events/handlers/ButtonHandler.js - Gestion des interactions de boutons
 // ========================================
 
+import { MessageFlags } from 'discord.js';
 import logger from '../logger.js';
 import { safeStringify } from '../utils/SafeStringify.js';
 
@@ -24,10 +25,9 @@ export async function handleButtonInteraction (interaction, _client, _db, _confi
       return await handleFullStatsButton(interaction);
     }
 
-    // Bouton non reconnu
     await interaction.reply({
       content: '❌ Bouton non reconnu',
-      flags: 64 // MessageFlags.Ephemeral
+      flags: MessageFlags.Ephemeral
     });
     return { success: true, message: 'BUTTON_HANDLED', ephemeral: false };
   } catch (error) {
@@ -35,7 +35,7 @@ export async function handleButtonInteraction (interaction, _client, _db, _confi
     try {
       await interaction.reply({
         content: '❌ Une erreur est survenue lors du traitement du bouton.',
-        flags: 64 // MessageFlags.Ephemeral
+        flags: MessageFlags.Ephemeral
       });
     } catch (replyError) {
       logger.error(
@@ -51,10 +51,9 @@ export async function handleButtonInteraction (interaction, _client, _db, _confi
  * Gérer les boutons de suggestion
  */
 async function handleSuggestionButton (interaction) {
-  // Traitement des boutons de suggestion...
   await interaction.reply({
     content: 'Action effectuée avec succès!',
-    flags: 64 // MessageFlags.Ephemeral
+    flags: MessageFlags.Ephemeral
   });
   return { success: true, message: 'BUTTON_HANDLED', ephemeral: false };
 }

--- a/src/bot/handlers/InteractionHandler.js
+++ b/src/bot/handlers/InteractionHandler.js
@@ -4,24 +4,27 @@ import { MessageFlags } from 'discord.js';
 // ========================================
 
 import logger from '../logger.js';
-import { handleTempVcButton, handleTempVcModal, isTempVcButton } from '../services/tempVcService.js';
+import {
+  handleTempVcButton,
+  handleTempVcModal,
+  isTempVcButton
+} from '../services/tempVcService.js';
+
 const COMPACT_LOGS = process.env.COMPACT_LOGS === 'true';
 
-/**
- * Traite une interaction selon son type
- * @param {Object} interaction - L'interaction Discord
- * @param {Object} client - Client Discord
- * @param {Object} db - Instance de base de données
- * @param {Object} config - Configuration
- * @returns {Object} Résultat du traitement
- */
+function failResult (message) {
+  return {
+    success: false,
+    message,
+    flags: MessageFlags.Ephemeral
+  };
+}
+
 export async function handleInteractionByType (interaction, client, db, config) {
   try {
     if (!COMPACT_LOGS) {
       logger.debug(
-        `Traitement de l'interaction ${
-          interaction.commandName || interaction.customId
-        }`,
+        `Traitement de l'interaction ${interaction.commandName || interaction.customId}`,
         {
           userId: interaction.user.id,
           commandName: interaction.commandName || interaction.customId,
@@ -30,91 +33,50 @@ export async function handleInteractionByType (interaction, client, db, config) 
       );
     }
 
-    // Gestion des slash commands
     if (interaction.isChatInputCommand()) {
       return await handleSlashCommand(interaction, client, db, config);
     }
 
-    // Gestion des boutons
     if (interaction.isButton()) {
       return await handleButton(interaction, client, db, config);
     }
 
-    // Gestion des select menus
     if (interaction.isStringSelectMenu()) {
       return await handleSelectMenu(interaction, client, db, config);
     }
 
-    // Gestion des modals
     if (interaction.isModalSubmit()) {
       return await handleModal(interaction, client, db, config);
     }
 
-    // Type d'interaction non supporté
     logger.warn(`Type d'interaction non supporté: ${interaction.type}`);
-    return {
-      success: false,
-      message: '❌ Type d\'interaction non supporté.',
-      flags: MessageFlags.Ephemeral
-    };
+    return failResult('❌ Type d\'interaction non supporté.');
   } catch (error) {
-    logger.error(
-      `Erreur dans handleInteractionByType: ${error.message}`,
-      error
-    );
-    return {
-      success: false,
-      message: '❌ Erreur lors du traitement de l\'interaction.',
-      flags: MessageFlags.Ephemeral
-    };
+    logger.error(`Erreur dans handleInteractionByType: ${error.message}`, error);
+    return failResult('❌ Erreur lors du traitement de l\'interaction.');
   }
 }
 
-/**
- * Traite une slash command
- * @param {Object} interaction - L'interaction de commande
- * @param {Object} client - Client Discord
- * @param {Object} db - Instance de base de données
- * @param {Object} config - Configuration
- * @returns {Object} Résultat de l'exécution
- */
 async function handleSlashCommand (interaction, client, db, config) {
   const { commandName } = interaction;
 
   try {
-    // Vérifier si la commande existe
     const command = client.commands?.get(commandName);
     if (!command) {
       logger.warn(`Commande "${commandName}" non trouvée dans client.commands`);
-      logger.debug(
-        `Commandes disponibles: ${Array.from(
-          client.commands?.keys() || []
-        ).join(', ')}`
-      );
-
-      return {
-        success: false,
-        message: `❌ La commande "${commandName}" n'existe pas.`,
-        flags: MessageFlags.Ephemeral
-      };
+      logger.debug(`Commandes disponibles: ${Array.from(client.commands?.keys() || []).join(', ')}`);
+      return failResult(`❌ La commande "${commandName}" n'existe pas.`);
     }
 
-    // Vérifier que la fonction execute existe
     if (typeof command.execute !== 'function') {
-      logger.error(
-        `La commande "${commandName}" n'a pas de méthode execute valide`
-      );
-      return {
-        success: false,
-        message: `❌ Erreur de configuration de la commande "${commandName}".`,
-        flags: MessageFlags.Ephemeral
-      };
+      logger.error(`La commande "${commandName}" n'a pas de méthode execute valide`);
+      return failResult(`❌ Erreur de configuration de la commande "${commandName}".`);
     }
 
-    if (!COMPACT_LOGS)
+    if (!COMPACT_LOGS) {
       logger.debug(`Exécution de la commande "${commandName}"`);
+    }
 
-    // Exécuter la commande avec contexte enrichi
     const context = {
       client,
       db,
@@ -125,14 +87,13 @@ async function handleSlashCommand (interaction, client, db, config) {
       channel: interaction.channel
     };
 
-    // Exécuter la commande
     const result = await command.execute(interaction, context);
-
-    // Normaliser le résultat
     const normalizedResult = normalizeCommandResult(result, commandName);
 
-    if (!COMPACT_LOGS)
+    if (!COMPACT_LOGS) {
       logger.debug(`Commande "${commandName}" exécutée avec succès`);
+    }
+
     return normalizedResult;
   } catch (error) {
     logger.error(`Erreur dans la commande ${commandName}:`, {
@@ -141,22 +102,10 @@ async function handleSlashCommand (interaction, client, db, config) {
       userId: interaction.user.id
     });
 
-    return {
-      success: false,
-      message: `❌ Erreur lors de l'exécution de la commande ${commandName}.`,
-      flags: MessageFlags.Ephemeral
-    };
+    return failResult(`❌ Erreur lors de l'exécution de la commande ${commandName}.`);
   }
 }
 
-/**
- * Traite les interactions de bouton
- * @param {Object} interaction - L'interaction de bouton
- * @param {Object} client - Client Discord
- * @param {Object} db - Instance de base de données
- * @param {Object} config - Configuration
- * @returns {Object} Résultat du traitement
- */
 async function handleButton (interaction) {
   const { customId } = interaction;
 
@@ -167,9 +116,6 @@ async function handleButton (interaction) {
       const result = await handleTempVcButton(interaction);
       if (result) return result;
     }
-
-    // Ici vous pourriez avoir un système de handlers de boutons
-    // Pour l'exemple, on traite quelques cas courants
 
     if (customId.startsWith('confirm_')) {
       await interaction.update({
@@ -187,27 +133,14 @@ async function handleButton (interaction) {
       return { success: true, message: 'BUTTON_HANDLED' };
     }
 
-    // Bouton non reconnu
     const { handleButtonInteraction } = await import('./ButtonHandler.js');
     return await handleButtonInteraction(interaction);
   } catch (error) {
     logger.error(`Erreur lors du traitement du bouton ${customId}:`, error);
-    return {
-      success: false,
-      message: '❌ Erreur lors du traitement du bouton.',
-      flags: MessageFlags.Ephemeral
-    };
+    return failResult('❌ Erreur lors du traitement du bouton.');
   }
 }
 
-/**
- * Traite les select menus
- * @param {Object} interaction - L'interaction de select menu
- * @param {Object} client - Client Discord
- * @param {Object} db - Instance de base de données
- * @param {Object} config - Configuration
- * @returns {Object} Résultat du traitement
- */
 async function handleSelectMenu (interaction) {
   const { customId } = interaction;
   const selectedValues = interaction.values;
@@ -215,7 +148,6 @@ async function handleSelectMenu (interaction) {
   try {
     logger.info(`Traitement du select menu: ${customId}`, { selectedValues });
 
-    // Exemple de traitement de select menu
     await interaction.reply({
       content: `Vous avez sélectionné: ${selectedValues.join(', ')}`,
       flags: MessageFlags.Ephemeral
@@ -223,26 +155,11 @@ async function handleSelectMenu (interaction) {
 
     return { success: true, message: 'SELECT_MENU_HANDLED' };
   } catch (error) {
-    logger.error(
-      `Erreur lors du traitement du select menu ${customId}:`,
-      error
-    );
-    return {
-      success: false,
-      message: '❌ Erreur lors du traitement de la sélection.',
-      flags: MessageFlags.Ephemeral
-    };
+    logger.error(`Erreur lors du traitement du select menu ${customId}:`, error);
+    return failResult('❌ Erreur lors du traitement de la sélection.');
   }
 }
 
-/**
- * Traite les soumissions de modal
- * @param {Object} interaction - L'interaction de modal
- * @param {Object} client - Client Discord
- * @param {Object} db - Instance de base de données
- * @param {Object} config - Configuration
- * @returns {Object} Résultat du traitement
- */
 async function handleModal (interaction) {
   const { customId } = interaction;
 
@@ -254,7 +171,6 @@ async function handleModal (interaction) {
       return tempVcResult;
     }
 
-    // Récupérer les valeurs des champs
     const fields = {};
     interaction.components.forEach((row) => {
       row.components.forEach((component) => {
@@ -264,7 +180,6 @@ async function handleModal (interaction) {
 
     logger.debug('Données du modal:', fields);
 
-    // Exemple de traitement
     await interaction.reply({
       content: '✅ Formulaire soumis avec succès!',
       flags: MessageFlags.Ephemeral
@@ -273,27 +188,15 @@ async function handleModal (interaction) {
     return { success: true, message: 'MODAL_HANDLED' };
   } catch (error) {
     logger.error(`Erreur lors du traitement du modal ${customId}:`, error);
-    return {
-      success: false,
-      message: '❌ Erreur lors du traitement du formulaire.',
-      flags: MessageFlags.Ephemeral
-    };
+    return failResult('❌ Erreur lors du traitement du formulaire.');
   }
 }
 
-/**
- * Normalise le résultat d'une commande pour une gestion cohérente
- * @param {*} result - Résultat brut de la commande
- * @param {string} commandName - Nom de la commande
- * @returns {Object} Résultat normalisé
- */
 function normalizeCommandResult (result, commandName) {
-  // Si c'est déjà un objet avec success, on le retourne tel quel
   if (result && typeof result === 'object' && 'success' in result) {
     return result;
   }
 
-  // Si c'est un string, on le traite comme un message de succès
   if (typeof result === 'string') {
     return {
       success: true,
@@ -302,7 +205,6 @@ function normalizeCommandResult (result, commandName) {
     };
   }
 
-  // Si c'est un objet Discord (embed, components, etc.)
   if (result && typeof result === 'object') {
     return {
       success: true,
@@ -311,7 +213,6 @@ function normalizeCommandResult (result, commandName) {
     };
   }
 
-  // Si c'est undefined/null, succès silencieux
   if (result === undefined || result === null) {
     return {
       success: true,
@@ -320,7 +221,6 @@ function normalizeCommandResult (result, commandName) {
     };
   }
 
-  // Fallback pour les autres types
   logger.warn(`Type de résultat inattendu pour ${commandName}:`, typeof result);
   return {
     success: true,
@@ -328,4 +228,3 @@ function normalizeCommandResult (result, commandName) {
     ephemeral: false
   };
 }
-

--- a/src/bot/handlers/SpecialCommandHandler.js
+++ b/src/bot/handlers/SpecialCommandHandler.js
@@ -2,6 +2,7 @@
 // bot/events/handlers/SpecialCommandHandler.js - Gestion des commandes spéciales
 // ========================================
 
+import { MessageFlags } from 'discord.js';
 import logger from '../logger.js';
 import stageMonitor from '../../core/services/StageMonitor.js';
 import stageSpeakerManager from '../../core/services/StageSpeakerManager.js';
@@ -22,23 +23,20 @@ export async function handleSpecialCommands (interaction, result, commandName) {
   }
 }
 
-/**
- * Traiter la commande play
- */
 async function handlePlayCommand (interaction) {
   try {
-    logger.info('🚀 Début de handlePlayCommand');
+    logger.info('Debut de handlePlayCommand');
 
     const { voice } = interaction.member;
     const channel = voice && voice.channel;
 
-    logger.info('📡 Vérification du canal vocal:', {
+    logger.info('Verification du canal vocal:', {
       hasVoice: !!voice,
       hasChannel: !!channel,
       channelType: channel?.type
     });
 
-    logger.info('📦 Import des modules audio...');
+    logger.info('Import des modules audio...');
     const {
       joinVoiceChannel,
       createAudioPlayer,
@@ -47,19 +45,19 @@ async function handlePlayCommand (interaction) {
       NoSubscriberBehavior,
       StreamType
     } = await import('@discordjs/voice');
-    logger.success('Modules audio importés avec succès');
+    logger.success('Modules audio importes avec succes');
 
     const config = (await import('../config.js')).default;
     const { STREAM_URL } = config;
-    logger.info('🔗 URL du stream récupérée:', STREAM_URL ? 'OK' : 'MANQUANTE');
+    logger.info('URL du stream récupérée:', STREAM_URL ? 'OK' : 'MANQUANTE');
 
     if (!STREAM_URL) {
-      logger.error('❌ STREAM_URL non configurée dans les variables d\'environnement');
+      logger.error('STREAM_URL non configurée dans les variables d\'environnement');
       await interaction.editReply('❌ URL du stream non configurée. Contactez un administrateur.');
       return;
     }
 
-    logger.info('🔌 Connexion au canal vocal...');
+    logger.info('Connexion au canal vocal...');
     let connection;
     try {
       connection = joinVoiceChannel({
@@ -70,7 +68,7 @@ async function handlePlayCommand (interaction) {
       });
       logger.success('Connexion établie');
     } catch (connectionError) {
-      logger.error('❌ Erreur de connexion vocale:', {
+      logger.error('Erreur de connexion vocale:', {
         message: connectionError.message,
         code: connectionError.code,
         channelId: channel.id,
@@ -80,7 +78,7 @@ async function handlePlayCommand (interaction) {
       return;
     }
 
-    logger.info('🎵 Création du player audio...');
+    logger.info('Création du player audio...');
     const player = createAudioPlayer({
       behaviors: {
         noSubscriber: NoSubscriberBehavior.Pause
@@ -88,11 +86,9 @@ async function handlePlayCommand (interaction) {
     });
     logger.success('Player créé');
 
-    // StreamType.Arbitrary évite la détection automatique de format
-    // et prévient le TimeoutNegativeWarning de @discordjs/voice
     const AUDIO_INPUT_TYPE = StreamType?.Arbitrary ?? undefined;
 
-    logger.info('🎼 Création de la ressource audio...');
+    logger.info('Création de la ressource audio...');
     let resource;
     try {
       resource = createAudioResource(STREAM_URL, {
@@ -101,7 +97,7 @@ async function handlePlayCommand (interaction) {
       });
       logger.success('Ressource audio créée');
     } catch (resourceError) {
-      logger.error('❌ Erreur de création de ressource audio:', {
+      logger.error('Erreur de création de ressource audio:', {
         message: resourceError.message,
         streamUrl: STREAM_URL
       });
@@ -109,24 +105,24 @@ async function handlePlayCommand (interaction) {
       return;
     }
 
-    logger.info('▶️ Lancement de la lecture...');
+    logger.info('Lancement de la lecture...');
     player.play(resource);
     connection.subscribe(player);
     logger.success('Lecture lancée');
 
     interaction.client.audio = { connection, player };
-    logger.info('💾 Audio sauvegardé dans client.audio');
+    logger.info('Audio sauvegardé dans client.audio');
 
     stageMonitor.registerStage(channel.guild.id, channel.id, channel.guild);
-    logger.info('🎭 Stage enregistré pour surveillance automatique');
+    logger.info('Stage enregistré pour surveillance automatique');
 
     const timeout = setTimeout(() => {
-      logger.warn('⏰ Timeout de 5s atteint');
+      logger.warn('Timeout de 5s atteint');
       interaction.editReply('⚠️ Aucun son détecté après 5s. Lecture échouée ?');
     }, 5000);
 
     player.once(AudioPlayerStatus.Playing, async () => {
-      logger.info('🎵 Événement Playing détecté');
+      logger.info('Événement Playing détecté');
       clearTimeout(timeout);
 
       try {
@@ -134,7 +130,7 @@ async function handlePlayCommand (interaction) {
 
         if (promotionResult.success) {
           await interaction.editReply('▶️ Stream lancé dans le stage channel. 🎤 Bot promu en speaker automatiquement.');
-          logger.success('🎤 Auto-promotion en speaker réussie');
+          logger.success('Auto-promotion en speaker réussie');
         } else {
           const missingPerms = stageSpeakerManager.formatMissingPermissions(
             promotionResult.missingPermissions || []
@@ -146,43 +142,38 @@ async function handlePlayCommand (interaction) {
             '▶️ Stream lancé dans le stage channel.\n⚠️ Auto-promotion en speaker échouée: '
             + `${promotionResult.message}\n${errorMessage}`
           );
-          logger.warn('🎤 Auto-promotion en speaker échouée:', promotionResult.message);
+          logger.warn('Auto-promotion en speaker échouée:', promotionResult.message);
         }
       } catch (promotionError) {
         await interaction.editReply(
           '▶️ Stream lancé dans le stage channel.\n⚠️ Erreur lors de l\'auto-promotion en speaker.'
         );
-        logger.error('🎤 Erreur lors de l\'auto-promotion:', promotionError);
+        logger.error('Erreur lors de l\'auto-promotion:', promotionError);
       }
 
       logger.success('Message de succès envoyé');
     });
 
     player.on('error', async (error) => {
-      logger.error('❌ Erreur du player:', {
+      logger.error('Erreur du player:', {
         message: error.message,
         code: error.code,
         stack: error.stack,
         streamUrl: STREAM_URL
       });
       clearTimeout(timeout);
-      await interaction.editReply(
-        `❌ Erreur pendant la lecture du stream: ${error.message}`
-      );
+      await interaction.editReply(`❌ Erreur pendant la lecture du stream: ${error.message}`);
     });
 
-    logger.success('handlePlayCommand terminé avec succès');
+    logger.success('handlePlayCommand termine avec succes');
   } catch (error) {
-    logger.error('❌ Erreur lors du traitement de la commande play:', error);
+    logger.error('Erreur lors du traitement de la commande play:', error);
     await interaction.editReply({
       content: '❌ Erreur lors de l\'exécution de la commande play.'
     });
   }
 }
 
-/**
- * Traiter la commande schedule
- */
 async function handleScheduleCommand (interaction, _result) {
   try {
     const scheduleCommand = await import('../../commands/schedule.js');
@@ -191,19 +182,19 @@ async function handleScheduleCommand (interaction, _result) {
     if (result && result.success) {
       await interaction.editReply({
         content: result.message,
-        flags: result.ephemeral !== false ? 64 : 0
+        flags: result.ephemeral !== false ? MessageFlags.Ephemeral : undefined
       });
     } else {
       await interaction.editReply({
         content: '❌ Erreur lors de l\'exécution de la commande schedule.',
-        flags: 64
+        flags: MessageFlags.Ephemeral
       });
     }
   } catch (error) {
     logger.error('Erreur lors du traitement de la commande schedule:', error);
     await interaction.editReply({
       content: '❌ Erreur lors de l\'exécution de la commande schedule.',
-      flags: 64
+      flags: MessageFlags.Ephemeral
     });
   }
 }


### PR DESCRIPTION
## Summary
- replace magic ephemeral flag values with `MessageFlags.Ephemeral`
- clean and normalize interaction handler messaging and error returns
- simplify `InteractionHandler` flow with a shared failure result helper

## Validation
- `npm run lint` passes
- tests are still blocked in this local environment by `spawn EPERM`